### PR TITLE
ci: add integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: test rust-bitcoinkernel devshell
+
+on:
+  push:
+    branches: [setup-ci]
+  pull_request:
+
+jobs:
+  integration-test:
+    name: rust-bitcoinkernel (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout devazoa (this repo)
+        uses: actions/checkout@v4
+
+      - name: Clone rust-bitcoinkernel
+        run: |
+          git clone https://github.com/theCharlatan/rust-bitcoinkernel.git ../rust-bitcoinkernel
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Run cargo test inside devshell
+        working-directory: ../rust-bitcoinkernel
+        run: |
+          nix develop ../devazoa#rust-bitcoinkernel --command cargo test --all
+


### PR DESCRIPTION
The primary purpose of devazoa is to enable a workflow like:

```
git clone <project> && cd <project>
nix develop "github:2140-dev/devazoa#project"
# or setup permanently with a .envrc file
```

For testing, this means we want to be sure that our flakes a) evaluate, and b) actually work for setting up the project, for each supported platform.

This adds a CI job for doing just this: clone `rust-bitcoinkernel`, `nix develop ..`, and `cargo test`. Somewhat brittle at the moment considering its pulling in the downstream project fresh each time, so a failure could result from a change outsider our repo. Leaving whether or not to pin these to a release of the downstream project for now, only because I think that will require more careful thought.

Note: this is currently failing for `x86_64-linux` on main, but merging as this will make testing a fix much easier. Up until now, I can usually get it working for one platform and then it's broken for the other platform and I'm finding it quite tedious to remember to test on both (hence the CI work).

