### PR TITLE
ci: update rust-bitcoinkernel branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clone rust-bitcoinkernel
-        run: |
-          git clone https://github.com/theCharlatan/rust-bitcoinkernel.git ../rust-bitcoinkernel
+        with:
+          repository: josibake/rust-bitcoinkernel
+          ref: make-build-script-more-generic
+          path: ../rust-bitcoinkernel
 
       - name: Set up Nix
         uses: cachix/install-nix-action@v24


### PR DESCRIPTION
Run integration test against the build script improvement branch. Will update to main if/when this branch merges, or update to a different branch to try out a different fix.